### PR TITLE
Fix fib issue: unsafe return of any type value 

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-module.exports = function fibonacci(n) {
+module.exports = function fibonacci(n: number): number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {

--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -4,7 +4,7 @@ import { Request, Response } from "express";
 import fibonacci from "./fib"; // Use import instead of require
 
 export default (req: Request, res: Response) => {
-  const { num } = req.params as { num: string }; // Specify num as a string
+  const {num} = req.params as { num: string }; // Specify num as a string
 
   const fibN = fibonacci(parseInt(num, 10)); // Safely parse to an integer
   let result = `fibonacci(${num}) is ${fibN}`;

--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,11 +1,12 @@
 // Endpoint for querying the fibonacci numbers
 
-const fibonacci = require("./fib");
+import { Request, Response } from "express";
+import fibonacci from "./fib"; // Use import instead of require
 
-export default (req, res) => {
-  const { num } = req.params;
+export default (req: Request, res: Response) => {
+  const { num } = req.params as { num: string }; // Specify num as a string
 
-  const fibN = fibonacci(parseInt(num));
+  const fibN = fibonacci(parseInt(num, 10)); // Safely parse to an integer
   let result = `fibonacci(${num}) is ${fibN}`;
 
   if (fibN < 0) {


### PR DESCRIPTION
I fixed this issue by restricting the parameters that can be passed to fibonacci function only to a number.